### PR TITLE
check for css_selector b4 set css_rules

### DIFF
--- a/assets/query-monitor.js
+++ b/assets/query-monitor.js
@@ -316,7 +316,9 @@ jQuery( function($) {
     
     // Extract and wrap the css rules
     function qm_get_css(id) {
-        var css_rules = document.querySelector('link[id="' + id + '"]').sheet.cssRules || document.querySelector('link[id="' + id + '"]').sheet.rules;
+        var css_selector = document.querySelector( 'link[id="' + id + '"]' );
+        if ( ! css_selector ) return '';
+        var css_rules = css_selector.sheet.cssRules || css_selector.sheet.rules;
         var css = '<style type="text/css">' + Array.prototype.map.call(css_rules, function (x) {
           return x.cssText;
         }).join('\n') + '</style>' + "\n";


### PR DESCRIPTION
Export would not work when attempting to use `qm_get_css('common-css')` and `qm_get_css('common-css')` on WordPress 4.5, clean install.  Reason being is `querySelector` returned null and attempting to use `.sheet` on null